### PR TITLE
Validation

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 import json
 import pytest
 import requests
+import yaml
 import zalando_deploy_cli.cli
 from unittest.mock import MagicMock, ANY
 
@@ -16,6 +17,16 @@ def mock_config(monkeypatch):
         'kubernetes_namespace': 'mynamespace'
     }
     monkeypatch.setattr('stups_cli.config.load_config', MagicMock(return_value=config))
+
+
+def test_create_deployment_validation():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('template.yaml', 'w') as fd:
+            yaml.dump({}, fd)
+
+        result = runner.invoke(cli, ['create-deployment', 'template.yaml', 'my-app2', 'v2-X', 'r42'])
+    assert 'Error: Invalid value for "version": does not match regular expression pattern "^[a-z0-9][a-z0-9.-]*$' in result.output
 
 
 def test_switch_deployment(monkeypatch, mock_config):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,7 @@ def mock_config(monkeypatch):
     monkeypatch.setattr('stups_cli.config.load_config', MagicMock(return_value=config))
 
 
-def test_create_deployment_validation():
+def test_create_deployment_invalid_argument():
     runner = CliRunner()
     with runner.isolated_filesystem():
         with open('template.yaml', 'w') as fd:
@@ -27,6 +27,20 @@ def test_create_deployment_validation():
 
         result = runner.invoke(cli, ['create-deployment', 'template.yaml', 'my-app2', 'v2-X', 'r42'])
     assert 'Error: Invalid value for "version": does not match regular expression pattern "^[a-z0-9][a-z0-9.-]*$' in result.output
+
+
+def test_create_deployment_success(monkeypatch):
+    request = MagicMock()
+    request.return_value.json.return_value = {'id': 'my-cr-id'}
+    monkeypatch.setattr('zalando_deploy_cli.cli.request', request)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('template.yaml', 'w') as fd:
+            yaml.dump({}, fd)
+
+        result = runner.invoke(cli, ['create-deployment', 'template.yaml', 'my-app', 'v1', 'r1', 'replicas=3'])
+    assert 'my-cr-id' == result.output.strip()
 
 
 def test_switch_deployment(monkeypatch, mock_config):

--- a/zalando_deploy_cli/cli.py
+++ b/zalando_deploy_cli/cli.py
@@ -21,21 +21,17 @@ APPLICATION_PATTERN = re.compile('^[a-z][a-z0-9-]*$')
 VERSION_PATTERN = re.compile('^[a-z0-9][a-z0-9.-]*$')
 
 
-def validate_application(ctx, param, value):
-    if not APPLICATION_PATTERN.match(value):
-        raise click.BadParameter('Application must satisfy regular expression pattern "[a-z][a-z0-9-]*"')
-    return value
+def validate_pattern(pattern):
+    def validate(ctx, param, value):
+        if not pattern.match(value):
+            raise click.BadParameter('does not match regular expression pattern "{}"'.format(pattern.pattern))
+        return value
+    return validate
 
 
-def validate_version(ctx, param, value):
-    if not VERSION_PATTERN.match(value):
-        raise click.BadParameter('Version/release must satisfy regular expression pattern "[a-z0-9][a-z0-9.-]*"')
-    return value
-
-
-application_argument = click.argument('application', callback=validate_application)
-version_argument = click.argument('version', callback=validate_version)
-release_argument = click.argument('release', callback=validate_version)
+application_argument = click.argument('application', callback=validate_pattern(APPLICATION_PATTERN))
+version_argument = click.argument('version', callback=validate_pattern(VERSION_PATTERN))
+release_argument = click.argument('release', callback=validate_pattern(VERSION_PATTERN))
 
 
 def request(method, url, headers=None, exit_on_error=True, **kwargs):


### PR DESCRIPTION
Add basic regex validation for `application`, `version` and `release`. This prevents problems with Kubernetes `metadata/name` as it does not allow uppercase characters for example.

Fixes #21.

