### PR TITLE
resolve-version to get latest Docker image

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 clickclick
 requests
 stups-zign
+stups-pierone
 pystache
 zalando-kubectl>=0.8

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -220,3 +220,15 @@ def test_encrypt(monkeypatch, mock_config):
     encrypt_call.assert_called_with(mock_config(), requests.post,
                                     mock_config().get('deploy_api') + '/secrets',
                                     json={'plaintext': 'my_secret'})
+
+
+def test_resolve_version(monkeypatch):
+    monkeypatch.setattr('zign.api.get_token', lambda a, b: 'mytok')
+    monkeypatch.setattr('pierone.api.get_latest_tag', lambda a, b: 'cd123')
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open('template.yaml', 'w') as fd:
+            yaml.dump({'spec': {'template': {'spec': {'containers': [{'image': 'myregistry.example.org/foo/bar:{{version}}'}]}}}}, fd)
+        result = runner.invoke(cli, ['resolve-version', 'template.yaml', 'my-app', 'latest', 'r1', 'replicas=3'], catch_exceptions=False)
+        print(result)
+    assert 'cd123' == result.output.strip()


### PR DESCRIPTION
Add new command to resolve potential "latest" version to latest Docker image version tag.

Usage:

```bash
$ resolved=$(zdeploy resolve-version deployment.yaml my-app latest r1)
$ zdeploy create-deployment deployment.yaml myapp $resolved r1
```

What it does:

* if the version is `latest`: find container using the `latest` tag and go to Pier One to find the latest tag
* if the version is not `latest`: return version as-is