### PR TITLE
Adds KMS encryption support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+boto3
 clickclick
 requests
 stups-zign

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, ANY
 
 from click.testing import CliRunner
 from zalando_deploy_cli.cli import (cli,
+                                    get_aws_account_name,
                                     get_replicas,
                                     get_owned_replicasets,
                                     delete_deployment,
@@ -518,6 +519,18 @@ def test_get_current_replicas(monkeypatch, mock_config):
     assert '3' == result.output.strip()
 
 
+def test_get_aws_account_name(monkeypatch):
+    zaws_config = {
+        "last_update": {'account_name': 'test'}
+    }
+    load_config = MagicMock(return_value=zaws_config)
+    monkeypatch.setattr('stups_cli.config.load_config', load_config)
+    assert get_aws_account_name() == 'test'
+
+    load_config.return_value = {}
+    assert get_aws_account_name() == "unknown-account"
+
+
 def test_encrypt(monkeypatch, mock_config):
     encrypt_call = MagicMock()
     encrypt_call.return_value = encrypt_call
@@ -572,9 +585,9 @@ def test_encrypt(monkeypatch, mock_config):
     assert "deployment-secret:autobahn-encrypted:barFooBAR=" == encrypted.strip()
 
 
-    #encrypt_call.assert_called_with(mock_config(), requests.post,
-    #                                mock_config().get('deploy_api') + '/secrets',
-    #                                json={'plaintext': 'my_secret'})
+    encrypt_call.assert_called_with(mock_config(), requests.post,
+                                    mock_config().get('deploy_api') + '/secrets',
+                                    json={'plaintext': 'my_secret'})
 
 
 def test_resolve_version(monkeypatch):

--- a/zalando_deploy_cli/cli.py
+++ b/zalando_deploy_cli/cli.py
@@ -50,12 +50,12 @@ EC2_INSTANCE_MEMORY = {
 }
 
 
-def get_aws_account_name(config, account_id: str) -> str:
+def get_aws_account_name() -> str:
+
     try:
-        # TODO take cluster from config
-        url = "https://cluster-registry.stups.zalan.do/infrastructure-accounts/aws:" + account_id
-        response = request(config, requests.get, url)
-        return response.json()["name"]
+        zaws_config = stups_cli.config.load_config("zalando-aws-cli")
+        current_account = zaws_config["last_update"]["account_name"]
+        return current_account
     except:
         return "unknown-account"
 
@@ -883,8 +883,7 @@ def encrypt(config, autobahn_fallback):
         encrypted = kms.encrypt(KeyId='alias/deployment-secret',
                                 Plaintext=plain_text.encode())
         encrypted = base64.b64encode(encrypted['CiphertextBlob'])
-        account_id = boto3.client('sts').get_caller_identity().get('Account')
-        account_name = get_aws_account_name(config, account_id)
+        account_name = get_aws_account_name()
         print("deployment-secret:{account_name}:{encrypted}".format(
             account_name=account_name,
             encrypted=encrypted.decode()

--- a/zalando_deploy_cli/cli.py
+++ b/zalando_deploy_cli/cli.py
@@ -894,8 +894,10 @@ def encrypt(config, autobahn_fallback):
         error_code = error_dict["Code"]
         if error_code == "NotFoundException":
             message = "KMS key 'deployment-secret' not found"
+        elif error_code == "ExpiredTokenException":
+            message = "Not logged in to AWS"
         else:
-            message = "Failed to encrypt with KM"
+            message = "Failed to encrypt with KMS"
 
         if autobahn_fallback:
             error("{}, falling back to autobahn".format(message))

--- a/zalando_deploy_cli/cli.py
+++ b/zalando_deploy_cli/cli.py
@@ -909,7 +909,6 @@ def encrypt(config, use_kms):
         print("deployment-secret:autobahn-encrypted:{}".format(encrypted))
 
 
-
 def copy_template(template_path: Path, path: Path, variables: dict):
     for d in template_path.iterdir():
         target_path = path / d.relative_to(template_path)


### PR DESCRIPTION
Makes `zdeploy encrypt` use the `deployment-secret` KMS key by default, keeping Autobahn encryption as a fallback.