### PR TITLE
Make zdeploy handle per cluster KMS keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,6 @@ All commands interacting with the "Autobahn" deployment API either need the ``--
     $ sudo pip3 install -U zalando-deploy-cli
     $ zdeploy configure \
         --deploy-api=https://deploy-api.example.org \
-        --registry-api=https://cluster-registry.example.org \
         --aws-account=aws:7.. \
         --aws-region=eu-central-1 \
         --kubernetes-cluster=aws:7..:kube-1

--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,7 @@ All commands interacting with the "Autobahn" deployment API either need the ``--
     $ sudo pip3 install -U zalando-deploy-cli
     $ zdeploy configure \
         --deploy-api=https://deploy-api.example.org \
+        --registry-api=https://cluster-registry.example.org \
         --aws-account=aws:7.. \
         --aws-region=eu-central-1 \
         --kubernetes-cluster=aws:7..:kube-1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -22,7 +22,7 @@ from zalando_deploy_cli.cli import (cli,
 def mock_config(monkeypatch):
     config = {
         'kubernetes_api_server': 'https://example.org',
-        'kubernetes_cluster': 'mycluster',
+        'kubernetes_cluster': 'aws:1234:region:mycluster',
         'kubernetes_namespace': 'mynamespace',
         'deploy_api': 'https://deploy.example.org'
     }
@@ -145,7 +145,7 @@ def test_switch_deployment_call_once(monkeypatch, mock_config):
 
     request.called_once_with(requests.patch,
                              ('https://example.org/kubernetes-clusters/'
-                              'mycluster/namespaces/mynamespace/resources'),
+                              'aws:1234:region:mycluster/namespaces/mynamespace/resources'),
                              json={'resources_update': ANY})
     assert result.exit_code == 0
 
@@ -538,14 +538,7 @@ def test_encrypt(monkeypatch, mock_config):
         'data': 'barFooBAR='
     })
 
-    registry_call = MagicMock()
-    registry_call.return_value = registry_call
-    registry_call.json = MagicMock(return_value={
-        'local_id': 'kube-1',
-    })
-
     monkeypatch.setattr('zalando_deploy_cli.cli.request', encrypt_call)
-    monkeypatch.setattr('zalando_deploy_cli.cli.request_url', registry_call)
 
     monkeypatch.setattr('zalando_deploy_cli.cli.get_aws_account_name',
                         MagicMock(return_value="test"))
@@ -577,7 +570,7 @@ def test_encrypt(monkeypatch, mock_config):
     )
 
     result = runner.invoke(cli, ['encrypt', '--use-kms'], input='my_secret')
-    assert "KMS key 'alias/kube-1-deployment-secret' not found" == result.output.strip()
+    assert "KMS key 'alias/mycluster-deployment-secret' not found" == result.output.strip()
 
     mock_boto.encrypt.side_effect = botocore.exceptions.ClientError(
         operation_name="test",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -537,7 +537,15 @@ def test_encrypt(monkeypatch, mock_config):
     encrypt_call.json = MagicMock(return_value={
         'data': 'barFooBAR='
     })
+
+    registry_call = MagicMock()
+    registry_call.return_value = registry_call
+    registry_call.json = MagicMock(return_value={
+        'local_id': 'kube-1',
+    })
+
     monkeypatch.setattr('zalando_deploy_cli.cli.request', encrypt_call)
+    monkeypatch.setattr('zalando_deploy_cli.cli.request_url', registry_call)
 
     monkeypatch.setattr('zalando_deploy_cli.cli.get_aws_account_name',
                         MagicMock(return_value="test"))
@@ -569,7 +577,7 @@ def test_encrypt(monkeypatch, mock_config):
     )
 
     result = runner.invoke(cli, ['encrypt', '--use-kms'], input='my_secret')
-    assert "KMS key 'deployment-secret' not found" == result.output.strip()
+    assert "KMS key 'alias/kube-1-deployment-secret' not found" == result.output.strip()
 
     mock_boto.encrypt.side_effect = botocore.exceptions.ClientError(
         operation_name="test",


### PR DESCRIPTION
With https://github.com/zalando-incubator/kubernetes-on-aws/pull/469 we change the KMS key from a per account key to a per cluster key.
This means zdeploy must be able to find the key for a particular cluster of the following format: `alias/{local_id}-deployment-secret`.

In order to get the `local_id` zdeploy must be able to look it up in the cluster-registry, so I have added this functionality to the encrypt command. It also means that zdeploy can now be configured with the cluster-registry URL via `--registry-api` flag on the `configure` command.

I also added a flag `--kms-keyid` to the encrypt command, so you can use a custom key.