### PR TITLE
Make KMS region configurable

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -570,7 +570,7 @@ def test_encrypt(monkeypatch, mock_config):
     )
 
     result = runner.invoke(cli, ['encrypt', '--use-kms'], input='my_secret')
-    assert "KMS key 'alias/mycluster-deployment-secret' not found" == result.output.strip()
+    assert "KMS key 'alias/mycluster-deployment-secret' not found. Please check your AWS region." == result.output.strip()
 
     mock_boto.encrypt.side_effect = botocore.exceptions.ClientError(
         operation_name="test",

--- a/zalando_deploy_cli/cli.py
+++ b/zalando_deploy_cli/cli.py
@@ -885,7 +885,7 @@ def encrypt(config, use_kms, kms_keyid):
             local_id = cluster.rsplit(':')[-1]
             kms_keyid = 'alias/{}-deployment-secret'.format(local_id)
         try:
-            kms = boto3.client("kms")
+            kms = boto3.client("kms", "eu-central-1")
             encrypted = kms.encrypt(KeyId=kms_keyid,
                                     Plaintext=plain_text.encode())
             encrypted = base64.b64encode(encrypted['CiphertextBlob'])


### PR DESCRIPTION
~~The KMS encryption keys are created in ``eu-central-1`` so we should make sure zdeploy always looks for them there.~~

KMS encryption keys are region specific so it should be possible for the user to provide a region if the key is not on their default region.